### PR TITLE
feat(op-rs, rollup): load rollup config from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,7 @@ dependencies = [
  "reth",
  "reth-node-ethereum",
  "rollup",
+ "serde_json",
  "superchain-registry",
  "tracing",
 ]
@@ -5003,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -5083,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "reth-auto-seal-consensus"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
@@ -5110,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -5133,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures",
  "itertools 0.13.0",
@@ -5167,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
@@ -5198,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -5210,7 +5211,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
@@ -5232,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5252,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "ahash",
  "backon",
@@ -5306,7 +5307,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5316,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5331,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5347,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -5358,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -5372,7 +5373,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
@@ -5382,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -5392,7 +5393,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5415,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -5445,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -5466,7 +5467,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
@@ -5492,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "bytes",
  "modular-bitfield",
@@ -5504,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5528,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5554,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -5576,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -5603,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "aes 0.8.4",
  "alloy-primitives",
@@ -5634,7 +5635,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-chainspec",
  "reth-payload-primitives",
@@ -5644,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures",
  "pin-project",
@@ -5668,7 +5669,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures",
  "metrics",
@@ -5703,7 +5704,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "eyre",
  "futures",
@@ -5732,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -5745,7 +5746,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -5770,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -5786,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -5798,7 +5799,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "reth-chainspec",
@@ -5816,7 +5817,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5833,7 +5834,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-errors",
@@ -5852,7 +5853,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -5862,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -5880,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
@@ -5898,7 +5899,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5914,7 +5915,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-execution-errors",
  "reth-primitives",
@@ -5926,7 +5927,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "eyre",
  "futures",
@@ -5953,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "reth-provider",
@@ -5963,7 +5964,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "serde",
  "serde_json",
@@ -5973,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5994,7 +5995,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -6010,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "bindgen",
  "cc",
@@ -6019,7 +6020,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures",
  "metrics",
@@ -6031,7 +6032,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics-derive"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6042,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6050,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -6062,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -6110,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -6133,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
@@ -6151,7 +6152,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6166,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -6180,7 +6181,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6200,7 +6201,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -6218,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-network",
  "aquamarine",
@@ -6275,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -6325,7 +6326,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "eyre",
  "reth-auto-seal-consensus",
@@ -6349,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rpc-types-engine",
  "futures",
@@ -6371,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "eyre",
  "http",
@@ -6395,12 +6396,12 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 
 [[package]]
 name = "reth-payload-builder"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures-util",
  "metrics",
@@ -6422,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-chain-state",
  "reth-chainspec",
@@ -6438,7 +6439,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "reth-chainspec",
  "reth-primitives",
@@ -6449,7 +6450,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -6478,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6498,7 +6499,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -6536,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
@@ -6562,7 +6563,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6576,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-eips",
  "reth-chainspec",
@@ -6592,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
@@ -6648,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-json-rpc",
  "jsonrpsee",
@@ -6662,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -6695,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
@@ -6723,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-rpc",
@@ -6759,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-sol-types",
  "derive_more 1.0.0",
@@ -6797,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -6810,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
@@ -6826,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -6844,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -6856,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -6890,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -6917,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6930,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
@@ -6950,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6962,7 +6963,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "auto_impl",
  "reth-chainspec",
@@ -6979,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
@@ -6990,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7008,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7018,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "clap",
  "eyre",
@@ -7033,7 +7034,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7065,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -7087,7 +7088,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7107,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -7131,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.0.5"
-source = "git+https://github.com/paradigmxyz/reth#c788b6a585bbbd7ed92aabc42cb612a6a804daff"
+source = "git+https://github.com/paradigmxyz/reth#dfcfe8d27166124324ba907d487ab7c27163373d"
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography", "cryptography::cryptocurrencies"]
 members = [
   "bin/hera",
   "bin/op-rs",
-  "crates/rollup",
   "crates/kona-providers",
+  "crates/rollup",
   "crates/ser",
 ]
 default-members = ["bin/hera"]

--- a/bin/op-rs/Cargo.toml
+++ b/bin/op-rs/Cargo.toml
@@ -24,3 +24,6 @@ reth-node-ethereum.workspace = true
 
 # OP Stack Dependencies
 superchain-registry = { workspace = true, default-features = false }
+
+# Misc
+serde_json = "1"

--- a/bin/op-rs/src/main.rs
+++ b/bin/op-rs/src/main.rs
@@ -5,15 +5,17 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use std::sync::Arc;
+use std::{fs::File, sync::Arc};
 
 use clap::Parser;
-use eyre::{bail, Result};
+use eyre::{bail, Context, Result};
 use reth::cli::Cli;
 use reth_node_ethereum::EthereumNode;
-use rollup::{Driver, HeraArgsExt, HERA_EXEX_ID};
+use serde_json::from_reader;
 use superchain_registry::ROLLUP_CONFIGS;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
+
+use rollup::{Driver, HeraArgsExt, HERA_EXEX_ID};
 
 /// The Reth CLI arguments with optional Hera Execution Extension support.
 #[derive(Debug, Clone, Parser)]
@@ -38,8 +40,19 @@ fn main() -> Result<()> {
                 bail!("Hera Execution Extension configuration is required when the `hera` flag is set");
             };
 
-            let Some(cfg) = ROLLUP_CONFIGS.get(&hera_args.l2_chain_id).cloned().map(Arc::new) else {
-                bail!("Rollup configuration not found for L2 chain ID: {}", hera_args.l2_chain_id);
+            let cfg = match &hera_args.l2_config_file {
+                Some(path) => {
+                    info!("Loading l2 config from file: {:?}", path);
+                    let file = File::open(path).wrap_err("Failed to open l2 config file")?;
+                    Arc::new(from_reader(file).wrap_err("Failed to read l2 config file")?)
+                }
+                None => {
+                    debug!("Loading l2 config from superchain registry");
+                    let Some(cfg) = ROLLUP_CONFIGS.get(&hera_args.l2_chain_id).cloned() else {
+                        bail!("Failed to find l2 config for chain ID {}", hera_args.l2_chain_id);
+                    };
+                    Arc::new(cfg)
+                }
             };
 
             let node = EthereumNode::default();

--- a/crates/rollup/src/cli.rs
+++ b/crates/rollup/src/cli.rs
@@ -21,6 +21,11 @@ pub struct HeraArgsExt {
     #[clap(long = "hera.l2-chain-id", default_value_t = DEFAULT_L2_CHAIN_ID)]
     pub l2_chain_id: u64,
 
+    /// Path to a custom L2 rollup configuration file
+    /// (overrides the default rollup configuration from the registry)
+    #[clap(long = "hera.l2-config-file")]
+    pub l2_config_file: Option<PathBuf>,
+
     /// RPC URL of an L2 execution client
     #[clap(long = "hera.l2-rpc-url", default_value = DEFAULT_L2_RPC_URL)]
     pub l2_rpc_url: Url,
@@ -46,7 +51,7 @@ pub struct HeraArgsExt {
     #[clap(
         long = "hera.validation-mode",
         default_value = "trusted",
-        requires_ifs([("engine-api", "l2-engine-api-url"), ("engine-api", "l2-engine-jwt-secret")]),
+        requires_ifs([("engine-api", "l2_engine_api_url"), ("engine-api", "l2_engine_jwt_secret")]),
     )]
     pub validation_mode: ValidationMode,
 


### PR DESCRIPTION
Adds the ability to load the rollup config from a file.
If no file is provided, the config will be loaded from the superchain registry as fallback.
