### PR TITLE
feat(rollup): init exex driver and pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7342,6 +7342,7 @@ dependencies = [
  "eyre",
  "kona-derive",
  "kona-primitives",
+ "kona-providers",
  "reqwest",
  "reth",
  "reth-exex",

--- a/bin/op-rs/src/main.rs
+++ b/bin/op-rs/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
             };
 
             let node = EthereumNode::default();
-            let hera = move |ctx| async { Ok(Driver::exex(ctx, hera_args, cfg).await.start()) };
+            let hera = move |ctx| async { Ok(Driver::exex(ctx, hera_args, cfg).start()) };
             let handle = builder.node(node).install_exex(HERA_EXEX_ID, hera).launch().await?;
             handle.wait_for_node_exit().await
         } else {

--- a/bin/op-rs/src/main.rs
+++ b/bin/op-rs/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
             };
 
             let node = EthereumNode::default();
-            let hera = move |ctx| async { Ok(Driver::new(ctx, hera_args, cfg).await.start()) };
+            let hera = move |ctx| async { Ok(Driver::exex(ctx, hera_args, cfg).await.start()) };
             let handle = builder.node(node).install_exex(HERA_EXEX_ID, hera).launch().await?;
             handle.wait_for_node_exit().await
         } else {

--- a/crates/kona-providers/src/blob_provider.rs
+++ b/crates/kona-providers/src/blob_provider.rs
@@ -18,6 +18,14 @@ use reth::primitives::BlobTransactionSidecar;
 use tracing::warn;
 use url::Url;
 
+/// A blob provider that first attempts to fetch blobs from a primary beacon client and
+/// falls back to a secondary blob archiver if the primary fails.
+///
+/// Any blob archiver just needs to implement the beacon
+/// [`blob_sidecars` API](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlobSidecars)
+pub type DurableBlobProvider =
+    OnlineBlobProviderWithFallback<OnlineBeaconClient, OnlineBeaconClient, SimpleSlotDerivation>;
+
 /// Layered [BlobProvider] for the Kona derivation pipeline.
 ///
 /// This provider wraps different blob sources in an ordered manner:
@@ -35,13 +43,9 @@ pub struct LayeredBlobProvider {
     /// This is used primarily during sync when archived blobs
     /// aren't provided by reth since they'll be too old.
     ///
-    /// The `WithFallback` setup allows to specify two different
+    /// The `Durable` setup allows to specify two different
     /// endpoints for a primary and a fallback blob provider.
-    online: OnlineBlobProviderWithFallback<
-        OnlineBeaconClient,
-        OnlineBeaconClient,
-        SimpleSlotDerivation,
-    >,
+    online: DurableBlobProvider,
 }
 
 /// A blob provider that hold blobs in memory.

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -10,6 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+kona-providers = { path = "../kona-providers" }
+
 # Workspace
 eyre.workspace = true
 tracing.workspace = true

--- a/crates/rollup/src/cli.rs
+++ b/crates/rollup/src/cli.rs
@@ -8,6 +8,9 @@ use url::Url;
 /// The default L2 chain ID to use. This corresponds to OP Mainnet.
 pub const DEFAULT_L2_CHAIN_ID: u64 = 10;
 
+/// The default L1 RPC URL to use.
+pub const DEFAULT_L1_RPC_URL: &str = "https://eth.llamarpc.com/";
+
 /// The default L2 RPC URL to use.
 pub const DEFAULT_L2_RPC_URL: &str = "https://optimism.llamarpc.com/";
 
@@ -29,6 +32,11 @@ pub struct HeraArgsExt {
     /// RPC URL of an L2 execution client
     #[clap(long = "hera.l2-rpc-url", default_value = DEFAULT_L2_RPC_URL)]
     pub l2_rpc_url: Url,
+
+    /// RPC URL of an L1 execution client
+    /// (This is only needed when running in Standalone mode)
+    #[clap(long = "hera.l1-rpc-url", default_value = DEFAULT_L1_RPC_URL)]
+    pub l1_rpc_url: Url,
 
     /// URL of an L1 beacon client to fetch blobs
     #[clap(long = "hera.l1-beacon-client-url", default_value = DEFAULT_L1_BEACON_CLIENT_URL)]


### PR DESCRIPTION
Added a `Driver::exex` method that can initialize a Driver with the components needed to bootstrap in ExEx mode.
Also stubbed a `StandaloneDriver` struct that will later be used to start Hera in standalone mode.

closes #8.