### PR TITLE
Remove `Default` trait for `ExecutionPayloadEnvelope`.

### DIFF
--- a/crates/net/src/driver.rs
+++ b/crates/net/src/driver.rs
@@ -1,13 +1,5 @@
 //! Driver for network services.
 
-use alloy::primitives::Address;
-use eyre::Result;
-use libp2p::swarm::SwarmEvent;
-use tokio::{
-    select,
-    sync::watch::{Receiver, Sender},
-};
-
 use crate::{
     builder::NetworkDriverBuilder,
     discovery::driver::DiscoveryDriver,
@@ -18,6 +10,11 @@ use crate::{
     },
     types::envelope::ExecutionPayloadEnvelope,
 };
+use alloy::primitives::Address;
+use eyre::Result;
+use libp2p::swarm::SwarmEvent;
+use std::sync::mpsc::Receiver;
+use tokio::{select, sync::watch};
 
 /// NetworkDriver
 ///
@@ -29,7 +26,7 @@ pub struct NetworkDriver {
     /// Channel to receive unsafe blocks.
     pub unsafe_block_recv: Receiver<ExecutionPayloadEnvelope>,
     /// Channel to send unsafe signer updates.
-    pub unsafe_block_signer_sender: Sender<Address>,
+    pub unsafe_block_signer_sender: watch::Sender<Address>,
     /// Block handler.
     pub handler: BlockHandler,
     /// The swarm instance.

--- a/crates/net/src/types/envelope.rs
+++ b/crates/net/src/types/envelope.rs
@@ -1,13 +1,13 @@
 //! Execution Payload Envelope Type
 
-use super::payload::{
-    ExecutionPayloadV1SSZ, ExecutionPayloadV2SSZ, ExecutionPayloadV3SSZ, PayloadHash,
-};
 use alloy::primitives::{Signature, B256};
 use eyre::Result;
 use kona_primitives::L2ExecutionPayload;
 use ssz_rs::prelude::*;
-use std::str::FromStr;
+
+use super::payload::{
+    ExecutionPayloadV1SSZ, ExecutionPayloadV2SSZ, ExecutionPayloadV3SSZ, PayloadHash,
+};
 
 /// An envelope around the execution payload for L2.
 #[derive(Debug, Clone)]
@@ -75,19 +75,5 @@ impl ExecutionPayloadEnvelope {
         let hash = PayloadHash::from(block_data);
 
         Ok(ExecutionPayloadEnvelope { parent_beacon_block_root, signature, payload, hash })
-    }
-}
-
-impl Default for ExecutionPayloadEnvelope {
-    fn default() -> Self {
-        Self {
-            payload: L2ExecutionPayload::default(),
-            // Generic signature taken from `alloy_primitives` tests.
-            //
-            // https://github.com/alloy-rs/core/blob/main/crates/primitives/src/signature/sig.rs#L614
-            signature: Signature::from_str("48b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c8041b").unwrap(),
-            hash: PayloadHash::default(),
-            parent_beacon_block_root: None,
-        }
     }
 }


### PR DESCRIPTION
Fix #36 . This PR removed the unnecessary `Default` trait impl for `ExecutionPayloadEnvelope`. 
Replace the watch channel to std mpsc channel which no init value needed.