### PR TITLE
feat(rollup): init telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,6 +1148,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "backon"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,12 +1264,15 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.76",
+ "which",
 ]
 
 [[package]]
@@ -1650,6 +1680,15 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2592,6 +2631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,6 +3008,7 @@ dependencies = [
  "reth-exex",
  "reth-node-api",
  "reth-node-ethereum",
+ "rollup",
  "superchain-registry",
  "tokio",
  "tracing",
@@ -3085,6 +3131,15 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4598,11 +4653,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls",
+ "hyper-util",
  "indexmap 2.4.0",
+ "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
  "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4702,6 +4764,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "modular-bitfield"
@@ -5511,6 +5579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8436,6 +8514,7 @@ dependencies = [
  "kona-derive",
  "kona-primitives",
  "kona-providers",
+ "metrics-exporter-prometheus",
  "reqwest",
  "reth",
  "reth-exex",
@@ -8444,6 +8523,7 @@ dependencies = [
  "superchain-registry",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -8568,6 +8648,7 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.8",
@@ -8649,6 +8730,7 @@ version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -10350,6 +10432,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/bin/hera/Cargo.toml
+++ b/bin/hera/Cargo.toml
@@ -11,6 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+# Local Dependencies
+rollup = { path = "../../crates/rollup" }
+
 # Workspace
 eyre.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/bin/hera/src/main.rs
+++ b/bin/hera/src/main.rs
@@ -7,5 +7,9 @@
 use eyre::Result;
 
 fn main() -> Result<()> {
-    unimplemented!()
+    rollup::init_telemetry_stack(8090)?;
+
+    tracing::info!("Hera OP Stack Rollup node");
+
+    Ok(())
 }

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -30,6 +30,10 @@ kona-derive.workspace = true
 kona-primitives.workspace = true
 superchain-registry = { workspace = true, default-features = false }
 
+# Telemetry
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }   
+metrics-exporter-prometheus = { version = "0.15.3", features = ["http-listener"] }
+
 # Misc
 url = "2.5.2"
 serde_json = "1"

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -16,5 +16,8 @@ pub use validator::AttributesValidator;
 mod pipeline;
 pub use pipeline::{new_rollup_pipeline, RollupPipeline};
 
+mod telemetry;
+pub use telemetry::init_telemetry_stack;
+
 /// The identifier of the Hera Execution Extension.
 pub const HERA_EXEX_ID: &str = "hera";

--- a/crates/rollup/src/telemetry.rs
+++ b/crates/rollup/src/telemetry.rs
@@ -1,0 +1,50 @@
+use std::{io::IsTerminal, net::SocketAddr};
+
+use eyre::{bail, Result};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tracing::{info, Level};
+use tracing_subscriber::{
+    fmt::Layer as FmtLayer, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
+};
+
+/// Initialize the tracing stack and Prometheus metrics recorder.
+///
+/// This function should be called at the beginning of the program.
+pub fn init_telemetry_stack(metrics_port: u16) -> Result<()> {
+    let filter = EnvFilter::builder().with_default_directive("hera=info".parse()?).from_env_lossy();
+
+    // Whether to use ANSI formatting and colors in the console output.
+    // If unset, always use colors if stdout is a tty.
+    // If set to "never", just disable all colors.
+    let should_use_colors = match std::env::var("RUST_LOG_STYLE") {
+        Ok(val) => val != "never",
+        Err(_) => std::io::stdout().is_terminal(),
+    };
+
+    // Whether to show the tracing target in the console output.
+    // If set, always show the target unless explicitly set to "0".
+    // If unset, show target only if the filter is more verbose than INFO.
+    let should_show_target = match std::env::var("RUST_LOG_TARGET") {
+        Ok(val) => val != "0",
+        Err(_) => filter.max_level_hint().map_or(true, |max_level| max_level > Level::INFO),
+    };
+
+    let std_layer = FmtLayer::new()
+        .with_ansi(should_use_colors)
+        .with_target(should_show_target)
+        .with_writer(std::io::stdout)
+        .with_filter(filter);
+
+    tracing_subscriber::registry().with(std_layer).try_init()?;
+
+    let prometheus_addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
+    let builder = PrometheusBuilder::new().with_http_listener(prometheus_addr);
+
+    if let Err(e) = builder.install() {
+        bail!("failed to install Prometheus recorder: {:?}", e);
+    } else {
+        info!("Telemetry initialized. Serving Prometheus metrics at: http://{}", prometheus_addr);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Added the ability to start tracing to `stdout` with the following options:

- tracing target: provided by default with `RUST_LOG` directives. Falls back to `hera=info` if not provided.
- whether to show the target in stdout: `RUST_LOG_TARGET` (don't show it only when set to `0`)
- whether to use ANSI formatting and colors: `RUST_LOG_STYLE` (don't use it only if set to `never`)

Also initialized a Prometheus subscriber on the provided port.
Tested on the Hera binary.

closes #33 