### PR TITLE
fix(net): Enr Data Encoding

### DIFF
--- a/crates/net/src/discovery/builder.rs
+++ b/crates/net/src/discovery/builder.rs
@@ -42,7 +42,9 @@ impl DiscoveryBuilder {
         let addr = self.address.ok_or_else(|| eyre::eyre!("address not set"))?;
         let chain_id = self.chain_id.ok_or_else(|| eyre::eyre!("chain ID not set"))?;
         let opstack = OpStackEnr::new(chain_id, 0);
-        let opstack_data: Vec<u8> = opstack.into();
+        let mut opstack_data = Vec::new();
+        use alloy_rlp::Encodable;
+        opstack.encode(&mut opstack_data);
 
         let key = CombinedKey::generate_secp256k1();
         let enr = Enr::builder().add_value_rlp(OP_CL_KEY, opstack_data.into()).build(&key)?;


### PR DESCRIPTION
### Description

Fixes Op Stack ENR data encoding + decoding.

Unfortunately the golang reference implementation decided to encode the opstack enr data using [unsigned varints and then using a byte string](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/p2p/discovery.go#L171-L210). This PR fixes the enr data encoding + decoding in the `net` crate to perform this encoding and decoding, with tests against two enr datas generated by the reference implementation.

Closes #58 