### PR TITLE
fix(net): Remove localhost Sockets

### DIFF
--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -32,6 +32,8 @@ println!("NetworkDriver started.");
 > check to make sure you are not using the loopback address,
 > `127.0.0.1` aka "localhost", which can prevent outward facing connections.
 
+[!WARNING]: ###example
+
 ### Acknowledgements
 
 Largely based off [magi](https://github.com/a16z/magi)'s [p2p module](https://github.com/a16z/magi/tree/master/src/network).

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -11,7 +11,7 @@ use op_net::driver::NetworkDriver;
 
 // Build the network driver.
 let signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
+let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
 let driver = NetworkDriver::builder()
     .with_chain_id(10) // op mainnet chain id
     .with_unsafe_block_signer(signer)

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -25,6 +25,13 @@ driver.start().expect("Failed to start network driver");
 println!("NetworkDriver started.");
 ```
 
+> [!WARNING]
+>
+> Notice, the socket address uses `0.0.0.0`.
+> If you are experiencing issues connecting to peers for discovery,
+> check to make sure you are not using the loopback address,
+> `127.0.0.1` aka "localhost", which can prevent outward facing connections.
+
 ### Acknowledgements
 
 Largely based off [magi](https://github.com/a16z/magi)'s [p2p module](https://github.com/a16z/magi/tree/master/src/network).

--- a/crates/net/src/builder.rs
+++ b/crates/net/src/builder.rs
@@ -122,7 +122,7 @@ impl NetworkDriverBuilder {
     ///
     /// let chain_id = 10;
     /// let signer = Address::random();
-    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
+    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
     ///
     /// // Let's say we want to enable flood publishing and use all other default settings.
     /// let cfg = config::default_config_builder().flood_publish(true).build().unwrap();
@@ -163,7 +163,7 @@ impl NetworkDriverBuilder {
     ///
     /// let chain_id = 10;
     /// let signer = Address::random();
-    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
+    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
     /// let driver = NetworkDriverBuilder::new()
     ///    .with_unsafe_block_signer(signer)
     ///    .with_chain_id(chain_id)
@@ -175,8 +175,8 @@ impl NetworkDriverBuilder {
     ///
     /// let chain_id = 10;
     /// let signer = Address::random();
-    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
-    /// let listen_config = ListenConfig::from_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9999);
+    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+    /// let listen_config = ListenConfig::from_ip(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9999);
     /// let driver = NetworkDriverBuilder::new()
     ///    .with_unsafe_block_signer(signer)
     ///    .with_chain_id(chain_id)
@@ -288,7 +288,7 @@ mod tests {
     fn test_build_custom_gossip_config() {
         let id = 10;
         let signer = Address::random();
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
         let cfg = config::default_config_builder().flood_publish(true).build().unwrap();
         let driver = NetworkDriverBuilder::new()
             .with_unsafe_block_signer(signer)
@@ -322,7 +322,7 @@ mod tests {
     fn test_build_default_network_driver() {
         let id = 10;
         let signer = Address::random();
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
         let driver = NetworkDriverBuilder::new()
             .with_unsafe_block_signer(signer)
             .with_chain_id(id)
@@ -355,8 +355,8 @@ mod tests {
     fn test_build_network_driver_with_discovery_addr() {
         let id = 10;
         let signer = Address::random();
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
-        let discovery_addr = ListenConfig::from_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9098);
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+        let discovery_addr = ListenConfig::from_ip(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9098);
         let driver = NetworkDriverBuilder::new()
             .with_unsafe_block_signer(signer)
             .with_chain_id(id)

--- a/crates/net/src/discovery/driver.rs
+++ b/crates/net/src/discovery/driver.rs
@@ -54,7 +54,7 @@ impl DiscoveryDriver {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9099);
+    ///     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
     ///     let mut discovery = DiscoveryBuilder::new()
     ///         .with_address(socket)
     ///         .with_chain_id(10) // OP Mainnet chain id


### PR DESCRIPTION
### Description

Removes localhost socket addrs to prevent loopback confusion during peer discovery.