### PR TITLE
fix(rollup): fallback HTTP polling without filtering

### DIFF
--- a/bin/hera/src/node.rs
+++ b/bin/hera/src/node.rs
@@ -26,10 +26,10 @@ impl NodeCommand {
 
         let ctx = StandaloneContext::new(self.hera_config.l1_rpc_url.clone()).await?;
         let cfg = self.hera_config.get_l2_config()?;
-        let driver = Driver::std(ctx, self.hera_config, cfg);
+        let driver = Driver::standalone(ctx, self.hera_config, cfg);
 
         if let Err(e) = driver.start().await {
-            bail!("Critical: Rollup driver failed: {:?}", e)
+            bail!("[CRIT] Rollup driver failed: {:?}", e)
         }
 
         Ok(())

--- a/crates/rollup/src/driver/context/standalone.rs
+++ b/crates/rollup/src/driver/context/standalone.rs
@@ -1,8 +1,8 @@
-use futures::StreamExt;
 use hashbrown::HashMap;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use alloy::{
+    eips::BlockId,
     network::Ethereum,
     primitives::{BlockNumber, B256},
     providers::{IpcConnect, Provider, ProviderBuilder, ReqwestProvider, WsConnect},
@@ -10,13 +10,14 @@ use alloy::{
     transports::{TransportErrorKind, TransportResult},
 };
 use async_trait::async_trait;
+use futures::StreamExt;
 use kona_primitives::TxEnvelope;
-use reth::rpc::types::{BlockTransactions, BlockTransactionsKind};
+use reth::rpc::types::BlockTransactions;
 use tokio::{
     sync::mpsc::{self, error::SendError},
     task::JoinHandle,
 };
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use url::Url;
 
 use super::{Blocks, ChainNotification, DriverContext};
@@ -65,28 +66,80 @@ impl StandaloneContext {
         let client = ReqwestProvider::<Ethereum>::new_http(l1_rpc_url);
         let (new_block_tx, new_block_rx) = mpsc::channel(128);
 
-        let mut new_block_hashes = client.watch_blocks().await?.into_stream();
-        let _handle = tokio::spawn(async move {
-            while let Some(hashes) = new_block_hashes.next().await {
-                for hash in hashes {
-                    match client.get_block_by_hash(hash, BlockTransactionsKind::Full).await {
-                        Ok(Some(block)) => {
-                            let block_with_txs = parse_reth_rpc_block(block);
-                            if let Err(e) = new_block_tx.try_send(block_with_txs) {
-                                error!("Failed to send new block to channel: {:?}", e);
+        let _handle = match client.watch_blocks().await {
+            Ok(new_block_hashes) => tokio::spawn(async move {
+                let mut stream = new_block_hashes.into_stream();
+                while let Some(hashes) = stream.next().await {
+                    for hash in hashes {
+                        match client.get_block_by_hash(hash, true.into()).await {
+                            Ok(Some(block)) => {
+                                let block_with_txs = parse_reth_rpc_block(block);
+                                if let Err(e) = new_block_tx.try_send(block_with_txs) {
+                                    error!("Failed to send new block to channel: {:?}", e);
+                                }
                             }
-                        }
-                        Ok(None) => {
-                            // Question: does `eth_getBlockByHash` return a block if it was
-                            // already reorged out? No-op for now.
-                        }
-                        Err(e) => {
-                            error!("Failed to get block by hash: {:?}", e);
+                            Ok(None) => {
+                                // Q: does `eth_getBlockByHash` return a block if it was
+                                // already reorged out? No-op for now.
+                                error!("Failed to get block by hash: block not found");
+                            }
+                            Err(e) => {
+                                error!("Failed to get block by hash: {:?}", e);
+                            }
                         }
                     }
                 }
+            }),
+            Err(err)
+                if err
+                    .as_error_resp()
+                    .is_some_and(|resp| resp.message.to_lowercase().contains("not supported")) =>
+            {
+                warn!("Filtering unavailable; falling back to eth_getBlock");
+                tokio::spawn(async move {
+                    let mut hash = B256::ZERO;
+                    loop {
+                        match client.get_block(BlockId::latest(), false.into()).await {
+                            Ok(Some(block)) => {
+                                if hash == block.header.hash {
+                                    // If the latest hash hasn't changed, wait before polling again
+                                    tokio::time::sleep(Duration::from_secs(2)).await;
+                                    continue;
+                                }
+                                hash = block.header.hash;
+
+                                // Every time we get a new hash, fetch the full block
+                                match client.get_block_by_hash(block.header.hash, true.into()).await
+                                {
+                                    Ok(Some(full_block)) => {
+                                        let block_with_txs = parse_reth_rpc_block(full_block);
+                                        if let Err(e) = new_block_tx.try_send(block_with_txs) {
+                                            error!("Failed to send new block to channel: {:?}", e);
+                                        }
+                                    }
+                                    other => {
+                                        error!("Failed to get full block by hash: {:?}", other)
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                error!("Failed to get latest block: block not found");
+                            }
+                            Err(e) => {
+                                error!("Failed to get latest block: {:?}", e);
+                            }
+                        };
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                })
             }
-        });
+
+            Err(err) => {
+                // On any error other than "not supported", return the error and fail.
+                error!("Failed to watch new blocks via HTTP");
+                return Err(err);
+            }
+        };
 
         Ok(Self::with_defaults(new_block_rx, _handle))
     }

--- a/crates/rollup/src/driver/cursor.rs
+++ b/crates/rollup/src/driver/cursor.rs
@@ -24,7 +24,7 @@ pub struct SyncCursor {
 }
 
 impl SyncCursor {
-    /// Create a new cursor with the default cache capacity.
+    /// Create a new cursor with the default cache capacity
     pub fn new(channel_timeout: u64) -> Self {
         // NOTE: capacity must be greater than the `channel_timeout` to allow
         // for derivation to proceed through a deep reorg.

--- a/crates/rollup/src/driver/mod.rs
+++ b/crates/rollup/src/driver/mod.rs
@@ -52,10 +52,7 @@ pub struct Driver<DC, CP, BP> {
     validator: Box<dyn AttributesValidator>,
 }
 
-impl<N> Driver<ExExContext<N>, InMemoryChainProvider, LayeredBlobProvider>
-where
-    N: FullNodeComponents,
-{
+impl<N: FullNodeComponents> Driver<ExExContext<N>, InMemoryChainProvider, LayeredBlobProvider> {
     /// Create a new Hera Execution Extension Driver
     pub fn exex(ctx: ExExContext<N>, args: HeraArgsExt, cfg: Arc<RollupConfig>) -> Self {
         let chain_provider =
@@ -218,17 +215,14 @@ where
 
     /// Fetch the new L2 tip and L1 origin block info for the given L2 block number.
     async fn fetch_new_tip(&mut self, l2_tip: u64) -> Result<(BlockInfo, L2BlockInfo)> {
-        let l2_block = self
-            .l2_chain_provider
-            .l2_block_info_by_number(l2_tip)
-            .await
-            .map_err(|e| eyre::eyre!(e))?;
+        let l2_block =
+            self.l2_chain_provider.l2_block_info_by_number(l2_tip).await.map_err(|e| eyre!(e))?;
 
         let l1_origin = self
             .l1_chain_provider
             .block_info_by_number(l2_block.l1_origin.number)
             .await
-            .map_err(|e| eyre::eyre!(e))?;
+            .map_err(|e| eyre!(e))?;
 
         Ok((l1_origin, l2_block))
     }

--- a/crates/rollup/src/driver/mod.rs
+++ b/crates/rollup/src/driver/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt::Debug, sync::Arc};
 
-use eyre::{bail, Result};
+use eyre::{bail, eyre, Result};
 use kona_derive::{
     errors::StageError,
     online::{AlloyChainProvider, AlloyL2ChainProvider, OnlineBlobProviderBuilder},
@@ -35,75 +35,73 @@ use cursor::SyncCursor;
 
 /// The Rollup Driver entrypoint.
 #[derive(Debug)]
-pub struct Driver<DC, CP, BP, L2CP> {
+pub struct Driver<DC, CP, BP> {
     /// The rollup configuration
     cfg: Arc<RollupConfig>,
     /// The context of the node
     ctx: DC,
     /// The L1 chain provider
-    chain_provider: CP,
+    l1_chain_provider: CP,
     /// The L1 blob provider
     blob_provider: BP,
     /// The L2 chain provider
-    l2_chain_provider: L2CP,
+    l2_chain_provider: AlloyL2ChainProvider,
     /// Cursor to keep track of the L2 tip
     cursor: SyncCursor,
     /// The validator to verify newly derived L2 attributes
     validator: Box<dyn AttributesValidator>,
 }
 
-impl<N> Driver<ExExContext<N>, InMemoryChainProvider, LayeredBlobProvider, AlloyL2ChainProvider>
+impl<N> Driver<ExExContext<N>, InMemoryChainProvider, LayeredBlobProvider>
 where
     N: FullNodeComponents,
 {
     /// Create a new Hera Execution Extension Driver
     pub fn exex(ctx: ExExContext<N>, args: HeraArgsExt, cfg: Arc<RollupConfig>) -> Self {
-        let cp = InMemoryChainProvider::with_capacity(args.in_mem_chain_provider_capacity);
-        let l2_cp = AlloyL2ChainProvider::new_http(args.l2_rpc_url.clone(), cfg.clone());
-        let bp = LayeredBlobProvider::new(
+        let chain_provider =
+            InMemoryChainProvider::with_capacity(args.in_mem_chain_provider_capacity);
+        let blob_provider = LayeredBlobProvider::new(
             args.l1_beacon_client_url.clone(),
             args.l1_blob_archiver_url.clone(),
         );
 
-        Self::with_components(ctx, args, cfg, cp, bp, l2_cp)
+        Self::with_components(ctx, args, cfg, chain_provider, blob_provider)
     }
 }
 
-impl Driver<StandaloneContext, AlloyChainProvider, DurableBlobProvider, AlloyL2ChainProvider> {
+impl Driver<StandaloneContext, AlloyChainProvider, DurableBlobProvider> {
     /// Create a new Standalone Hera Driver
-    pub fn std(ctx: StandaloneContext, args: HeraArgsExt, cfg: Arc<RollupConfig>) -> Self {
-        let cp = AlloyChainProvider::new_http(args.l1_rpc_url.clone());
-        let l2_cp = AlloyL2ChainProvider::new_http(args.l2_rpc_url.clone(), cfg.clone());
-        let bp = OnlineBlobProviderBuilder::new()
+    pub fn standalone(ctx: StandaloneContext, args: HeraArgsExt, cfg: Arc<RollupConfig>) -> Self {
+        let chain_provider = AlloyChainProvider::new_http(args.l1_rpc_url.clone());
+        let blob_provider = OnlineBlobProviderBuilder::new()
             .with_primary(args.l1_beacon_client_url.to_string())
             .with_fallback(args.l1_blob_archiver_url.clone().map(|url| url.to_string()))
             .build();
 
-        Self::with_components(ctx, args, cfg, cp, bp, l2_cp)
+        Self::with_components(ctx, args, cfg, chain_provider, blob_provider)
     }
 }
 
-impl<DC, CP, BP, L2CP> Driver<DC, CP, BP, L2CP>
+impl<DC, CP, BP> Driver<DC, CP, BP>
 where
     DC: DriverContext,
     CP: ChainProvider + Clone + Send + Sync + Debug + 'static,
     BP: BlobProvider + Clone + Send + Sync + Debug + 'static,
-    L2CP: L2ChainProvider + Clone + Send + Sync + Debug + 'static,
 {
     /// Create a new Hera Driver with the provided components.
     fn with_components(
         ctx: DC,
         args: HeraArgsExt,
         cfg: Arc<RollupConfig>,
-        chain_provider: CP,
+        l1_chain_provider: CP,
         blob_provider: BP,
-        l2_chain_provider: L2CP,
     ) -> Self {
         let cursor = SyncCursor::new(cfg.channel_timeout);
         let validator: Box<dyn AttributesValidator> = match args.validation_mode {
-            ValidationMode::Trusted => {
-                Box::new(TrustedValidator::new_http(args.l2_rpc_url, cfg.canyon_time.unwrap_or(0)))
-            }
+            ValidationMode::Trusted => Box::new(TrustedValidator::new_http(
+                args.l2_rpc_url.clone(),
+                cfg.canyon_time.unwrap_or(0),
+            )),
             ValidationMode::EngineApi => Box::new(EngineApiValidator::new_http(
                 args.l2_engine_api_url.expect("Missing L2 engine API URL"),
                 match args.l2_engine_jwt_secret.as_ref() {
@@ -112,21 +110,22 @@ where
                 },
             )),
         };
+        let l2_chain_provider = AlloyL2ChainProvider::new_http(args.l2_rpc_url, cfg.clone());
 
-        Self { cfg, ctx, chain_provider, blob_provider, l2_chain_provider, cursor, validator }
+        Self { cfg, ctx, l1_chain_provider, blob_provider, l2_chain_provider, cursor, validator }
     }
 
-    /// Wait for the L2 genesis L1 block (aka "origin block") to be available in the L1 chain.
+    /// Wait for the L2 genesis' corresponding L1 block to be available in the L1 chain.
     async fn wait_for_l2_genesis_l1_block(&mut self) -> Result<()> {
         loop {
             if let Some(notification) = self.ctx.recv_notification().await {
                 if let Some(new_chain) = notification.new_chain() {
                     let tip = new_chain.tip();
                     // TODO: commit the chain to a local buffered provider
-                    // self.chain_provider.commit_chain(new_chain);
+                    // self.l1_chain_provider.commit_chain(new_chain);
 
                     if let Err(err) = self.ctx.send_processed_tip_event(tip) {
-                        bail!("Critical: Failed to send processed tip event: {:?}", err);
+                        bail!("Failed to send processed tip event: {:?}", err);
                     }
 
                     if tip >= self.cfg.genesis.l1.number {
@@ -140,25 +139,27 @@ where
     }
 
     /// Initialize the rollup pipeline from the driver's components.
-    fn init_pipeline(&mut self) -> RollupPipeline<CP, BP, L2CP> {
-        new_rollup_pipeline(
+    async fn init_pipeline(&mut self) -> Result<RollupPipeline<CP, BP>> {
+        // Fetch the current L2 tip and its corresponding L1 origin block
+        let l2_tip = self.l2_chain_provider.latest_block_number().await.map_err(|e| eyre!(e))?;
+        let (l2_tip_l1_origin, l2_tip_block_info) = self.fetch_new_tip(l2_tip).await?;
+
+        // Advance the cursor to the L2 tip before starting the pipeline
+        self.cursor.advance(l2_tip_l1_origin, l2_tip_block_info);
+
+        Ok(new_rollup_pipeline(
             self.cfg.clone(),
-            self.chain_provider.clone(),
+            self.l1_chain_provider.clone(),
             self.blob_provider.clone(),
             self.l2_chain_provider.clone(),
-            // TODO: use a dynamic "tip" block instead of genesis
-            BlockInfo {
-                hash: self.cfg.genesis.l2.hash,
-                number: self.cfg.genesis.l2.number,
-                ..Default::default()
-            },
-        )
+            l2_tip_l1_origin,
+        ))
     }
 
     /// Advance the pipeline to the next L2 block.
     ///
     /// Returns `true` if the pipeline can move forward again, `false` otherwise.
-    async fn step(&mut self, pipeline: &mut RollupPipeline<CP, BP, L2CP>) -> bool {
+    async fn step(&mut self, pipeline: &mut RollupPipeline<CP, BP>) -> bool {
         let l2_tip = self.cursor.tip();
 
         match pipeline.step(l2_tip).await {
@@ -224,7 +225,7 @@ where
             .map_err(|e| eyre::eyre!(e))?;
 
         let l1_origin = self
-            .chain_provider
+            .l1_chain_provider
             .block_info_by_number(l2_block.l1_origin.number)
             .await
             .map_err(|e| eyre::eyre!(e))?;
@@ -236,7 +237,7 @@ where
     async fn handle_notification(
         &mut self,
         notification: ChainNotification,
-        pipeline: &mut RollupPipeline<CP, BP, L2CP>,
+        pipeline: &mut RollupPipeline<CP, BP>,
     ) -> Result<()> {
         if let Some(reverted_chain) = notification.reverted_chain() {
             // The reverted chain contains the list of blocks that were invalidated by the
@@ -256,10 +257,10 @@ where
 
         if let Some(new_chain) = notification.new_chain() {
             let tip = new_chain.tip();
-            // self.chain_provider.commit_chain(new_chain);
+            // self.l1_chain_provider.commit_chain(new_chain);
 
             if let Err(err) = self.ctx.send_processed_tip_event(tip) {
-                bail!("Critical: Failed to send processed tip event: {:?}", err);
+                bail!("Failed to send processed tip event: {:?}", err);
             }
         }
 
@@ -280,7 +281,8 @@ where
         info!("L1 chain synced to the rollup genesis block");
 
         // Step 2: Initialize the rollup pipeline
-        let mut pipeline = self.init_pipeline();
+        let mut pipeline = self.init_pipeline().await?;
+        info!("Derivation pipeline initialized");
 
         // Step 3: Start the processing loop
         loop {

--- a/crates/rollup/src/pipeline.rs
+++ b/crates/rollup/src/pipeline.rs
@@ -3,12 +3,12 @@
 use std::{fmt::Debug, sync::Arc};
 
 use kona_derive::{
-    online::{DerivationPipeline, EthereumDataSource, PipelineBuilder},
+    online::{AlloyL2ChainProvider, DerivationPipeline, EthereumDataSource, PipelineBuilder},
     stages::{
         AttributesQueue, BatchQueue, ChannelBank, ChannelReader, FrameQueue, L1Retrieval,
         L1Traversal, StatefulAttributesBuilder,
     },
-    traits::{BlobProvider, ChainProvider, L2ChainProvider},
+    traits::{BlobProvider, ChainProvider},
 };
 use kona_primitives::{BlockInfo, RollupConfig};
 
@@ -26,25 +26,24 @@ type L1AttributesQueue<CP, BP, L2CP> = AttributesQueue<
 /// A derivation pipeline generic over:
 /// - The L1 [ChainProvider] (CP)
 /// - The L1 [BlobProvider] (BP)
-/// - The [L2ChainProvider] (L2CP)
 ///
 /// This pipeline is a derivation pipeline that takes the outputs of the [FrameQueue] stage
 /// and transforms them into [L2PayloadAttributes](kona_primitives::L2PayloadAttributes).
-pub type RollupPipeline<CP, BP, L2CP> = DerivationPipeline<L1AttributesQueue<CP, BP, L2CP>, L2CP>;
+pub type RollupPipeline<CP, BP> =
+    DerivationPipeline<L1AttributesQueue<CP, BP, AlloyL2ChainProvider>, AlloyL2ChainProvider>;
 
 /// Creates a new [RollupPipeline] from the given components.
 #[allow(unused)]
-pub fn new_rollup_pipeline<CP, BP, L2CP>(
+pub fn new_rollup_pipeline<CP, BP>(
     cfg: Arc<RollupConfig>,
     chain_provider: CP,
     blob_provider: BP,
-    l2_chain_provider: L2CP,
+    l2_chain_provider: AlloyL2ChainProvider,
     origin: BlockInfo,
-) -> RollupPipeline<CP, BP, L2CP>
+) -> RollupPipeline<CP, BP>
 where
     CP: ChainProvider + Send + Sync + Clone + Debug,
     BP: BlobProvider + Send + Sync + Clone + Debug,
-    L2CP: L2ChainProvider + Send + Sync + Clone + Debug,
 {
     let dap = EthereumDataSource::new(chain_provider.clone(), blob_provider.clone(), &cfg.clone());
     let attributes = StatefulAttributesBuilder::new(


### PR DESCRIPTION
Introduces a second method of polling via HTTP that doesn't rely on the `eth_filter` feature.
This will be auto-detected and triggered as fallback. It's mostly useful for test purposes.

- Fixes #87 

## Stack

- main
  - #88 
    - 👉 #89