### PR TITLE
feat(rollup): abstract L1 cache behind `ExExHeraContext`

### DIFF
--- a/bin/hera/src/node.rs
+++ b/bin/hera/src/node.rs
@@ -2,7 +2,7 @@
 
 use clap::Args;
 use eyre::{bail, Result};
-use rollup::{Driver, HeraArgsExt, StandaloneContext};
+use rollup::{Driver, HeraArgsExt};
 use tracing::info;
 
 use crate::globals::GlobalArgs;
@@ -24,9 +24,8 @@ impl NodeCommand {
             self.hera_config.validation_mode
         );
 
-        let ctx = StandaloneContext::new(self.hera_config.l1_rpc_url.clone()).await?;
         let cfg = self.hera_config.get_l2_config()?;
-        let driver = Driver::standalone(ctx, self.hera_config, cfg);
+        let driver = Driver::standalone(self.hera_config, cfg).await?;
 
         if let Err(e) = driver.start().await {
             bail!("[CRIT] Rollup driver failed: {:?}", e)

--- a/crates/rollup/src/cli.rs
+++ b/crates/rollup/src/cli.rs
@@ -78,12 +78,12 @@ pub struct HeraArgsExt {
     #[clap(long = "hera.l2-engine-jwt-secret")]
     pub l2_engine_jwt_secret: Option<PathBuf>,
 
-    /// The maximum number of blocks to keep in memory in the chain provider.
+    /// The maximum **number of blocks** to keep cached in the chain provider.
     ///
     /// This is used to limit the memory usage of the chain provider.
     /// When the limit is reached, the oldest blocks are discarded.
-    #[clap(long = "hera.in-mem-chain-provider-capacity", default_value_t = 256)]
-    pub in_mem_chain_provider_capacity: usize,
+    #[clap(long = "hera.l1-chain-cache-size", default_value_t = 256)]
+    pub l1_chain_cache_size: usize,
 }
 
 impl HeraArgsExt {

--- a/crates/rollup/src/driver/context/exex.rs
+++ b/crates/rollup/src/driver/context/exex.rs
@@ -7,6 +7,12 @@ use tokio::sync::mpsc::error::SendError;
 
 use crate::driver::{ChainNotification, DriverContext};
 
+/// Execution extension Hera context.
+///
+/// This context is used to bridge the gap between the execution extension
+/// and the Hera pipeline. It receives notifications from the execution extension
+/// and forwards them to the Hera pipeline. It also maintains a shared L1 cache of
+/// the chain to make it available to the rollup pipeline.
 pub struct ExExHeraContext<N: FullNodeComponents> {
     ctx: ExExContext<N>,
     l1_cache: InMemoryChainProvider,

--- a/crates/rollup/src/driver/context/exex.rs
+++ b/crates/rollup/src/driver/context/exex.rs
@@ -1,19 +1,39 @@
 use alloy::primitives::BlockNumber;
 use async_trait::async_trait;
+use kona_providers::InMemoryChainProvider;
 use reth_exex::{ExExContext, ExExEvent};
 use reth_node_api::FullNodeComponents;
 use tokio::sync::mpsc::error::SendError;
 
 use crate::driver::{ChainNotification, DriverContext};
 
+pub struct ExExHeraContext<N: FullNodeComponents> {
+    ctx: ExExContext<N>,
+    l1_cache: InMemoryChainProvider,
+}
+
+impl<N: FullNodeComponents> ExExHeraContext<N> {
+    /// Create a new execution extension Hera context with the given
+    /// execution context and L1 cache.
+    pub fn new(ctx: ExExContext<N>, l1_cache: InMemoryChainProvider) -> Self {
+        Self { ctx, l1_cache }
+    }
+}
+
 #[async_trait]
-impl<N: FullNodeComponents> DriverContext for ExExContext<N> {
+impl<N: FullNodeComponents> DriverContext for ExExHeraContext<N> {
     async fn recv_notification(&mut self) -> Option<ChainNotification> {
-        let exex_notification = self.notifications.recv().await?;
+        let exex_notification = self.ctx.notifications.recv().await?;
+
+        // Commit the new chain to the L1 cache to make it available to the pipeline
+        if let Some(chain) = exex_notification.committed_chain() {
+            self.l1_cache.commit(chain);
+        }
+
         Some(ChainNotification::from(exex_notification))
     }
 
     fn send_processed_tip_event(&mut self, tip: BlockNumber) -> Result<(), SendError<BlockNumber>> {
-        self.events.send(ExExEvent::FinishedHeight(tip)).map_err(|_| SendError(tip))
+        self.ctx.events.send(ExExEvent::FinishedHeight(tip)).map_err(|_| SendError(tip))
     }
 }

--- a/crates/rollup/src/driver/context/mod.rs
+++ b/crates/rollup/src/driver/context/mod.rs
@@ -15,9 +15,10 @@ use reth_exex::ExExNotification;
 use tokio::sync::mpsc::error::SendError;
 
 mod exex;
+pub use exex::ExExHeraContext;
 
 mod standalone;
-pub use standalone::StandaloneContext;
+pub use standalone::StandaloneHeraContext;
 
 /// Context for the rollup driver.
 ///

--- a/crates/rollup/src/driver/context/standalone.rs
+++ b/crates/rollup/src/driver/context/standalone.rs
@@ -26,7 +26,11 @@ use super::{Blocks, ChainNotification, DriverContext};
 /// Equivalent to 2 epochs at 32 slots/epoch on Ethereum Mainnet.
 const FINALIZATION_TIMEOUT: u64 = 64;
 
-#[allow(unused)]
+/// A standalone context that polls for new blocks from an L1 node, depending
+/// on the URL scheme. Supported schemes are `http`, `ws`, and `file`.
+///
+/// If the URL scheme is `http`, the context will poll for new blocks using the
+/// `eth_getFilterChanges` if available, falling back to `eth_getBlockByNumber` if not.
 #[derive(Debug)]
 pub struct StandaloneHeraContext {
     /// The current tip of the L1 chain listener, used to detect reorgs

--- a/crates/rollup/src/driver/context/standalone.rs
+++ b/crates/rollup/src/driver/context/standalone.rs
@@ -28,7 +28,7 @@ const FINALIZATION_TIMEOUT: u64 = 64;
 
 #[allow(unused)]
 #[derive(Debug)]
-pub struct StandaloneContext {
+pub struct StandaloneHeraContext {
     /// The current tip of the L1 chain listener, used to detect reorgs
     l1_tip: BlockNumber,
     /// Channel that receives new blocks from the L1 node
@@ -44,7 +44,7 @@ pub struct StandaloneContext {
     _handle: JoinHandle<()>,
 }
 
-impl StandaloneContext {
+impl StandaloneHeraContext {
     /// Create a new standalone context that polls for new chains.
     pub async fn new(l1_rpc_url: Url) -> TransportResult<Self> {
         if l1_rpc_url.scheme().contains("http") {
@@ -191,7 +191,7 @@ impl StandaloneContext {
 }
 
 #[async_trait]
-impl DriverContext for StandaloneContext {
+impl DriverContext for StandaloneHeraContext {
     async fn recv_notification(&mut self) -> Option<ChainNotification> {
         // TODO: is it ok to skip fetching full txs and receipts here assuming the node will
         // have a fallback online RPC for that downstream? The driver and provider should be
@@ -256,7 +256,7 @@ mod tests {
             return Ok(());
         }
 
-        let mut ctx = StandaloneContext::new(url).await?;
+        let mut ctx = StandaloneHeraContext::new(url).await?;
 
         let notif = ctx.recv_notification().await.unwrap();
 
@@ -275,7 +275,7 @@ mod tests {
             return Ok(());
         }
 
-        let mut ctx = StandaloneContext::new(url).await?;
+        let mut ctx = StandaloneHeraContext::new(url).await?;
 
         let notif = ctx.recv_notification().await.unwrap();
 
@@ -289,7 +289,7 @@ mod tests {
     async fn test_reorg_cache_pruning() {
         let (_, rx) = mpsc::channel(128);
         let handle = tokio::spawn(async {});
-        let mut ctx = StandaloneContext::with_defaults(rx, handle);
+        let mut ctx = StandaloneHeraContext::with_defaults(rx, handle);
 
         // Simulate receiving 100 blocks
         for i in 1..=100 {
@@ -315,7 +315,7 @@ mod tests {
     async fn test_send_processed_tip_event() {
         let (_, rx) = mpsc::channel(128);
         let handle = tokio::spawn(async {});
-        let mut ctx = StandaloneContext::with_defaults(rx, handle);
+        let mut ctx = StandaloneHeraContext::with_defaults(rx, handle);
 
         // Send a processed tip event
         let result = ctx.send_processed_tip_event(100);

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod driver;
-pub use driver::{Driver, StandaloneContext};
+pub use driver::Driver;
 
 mod cli;
 pub use cli::HeraArgsExt;


### PR DESCRIPTION
This PR introduces a new wrapper struct: `ExExHeraContext`. 

This struct wraps `ExExContext` with a copy of `InMemoryChainProvider`, such that every newly committed chain gets automatically injected into the same L1 provider cache that's used by the rollup pipeline when running as ExEx.

This abstraction allows us to stop worrying about caching L1 blocks (which was previously marked as TODO in the derivation loop) and also makes full use of the data inside `Arc<Chain>`, such as receipts.

### Stack

- main
  - #88 
    - #89 
      - 👉 #91