### PR TITLE
fix: trim last / from urls

### DIFF
--- a/crates/kona-providers/src/blob_provider.rs
+++ b/crates/kona-providers/src/blob_provider.rs
@@ -96,8 +96,10 @@ impl LayeredBlobProvider {
         let memory = Arc::new(Mutex::new(InnerBlobProvider::with_capacity(512)));
 
         let online = OnlineBlobProviderBuilder::new()
-            .with_primary(beacon_client_url.to_string())
-            .with_fallback(blob_archiver_url.map(|url| url.to_string()))
+            .with_primary(beacon_client_url.as_str().trim_end_matches('/').to_string())
+            .with_fallback(
+                blob_archiver_url.map(|url| url.as_str().trim_end_matches('/').to_string()),
+            )
             .build();
 
         Self { memory, online }

--- a/crates/rollup/src/driver/mod.rs
+++ b/crates/rollup/src/driver/mod.rs
@@ -74,8 +74,12 @@ impl Driver<StandaloneHeraContext, AlloyChainProvider, DurableBlobProvider> {
     pub async fn standalone(args: HeraArgsExt, cfg: Arc<RollupConfig>) -> Result<Self> {
         let chain_provider = AlloyChainProvider::new_http(args.l1_rpc_url.clone());
         let blob_provider = OnlineBlobProviderBuilder::new()
-            .with_primary(args.l1_beacon_client_url.to_string())
-            .with_fallback(args.l1_blob_archiver_url.clone().map(|url| url.to_string()))
+            .with_primary(args.l1_beacon_client_url.as_str().trim_end_matches('/').to_string())
+            .with_fallback(
+                args.l1_blob_archiver_url
+                    .clone()
+                    .map(|url| url.as_str().trim_end_matches('/').to_string()),
+            )
             .build();
 
         // The Standalone Hera context is responsible for handling notifications from the node.
@@ -166,7 +170,7 @@ where
         let l2_tip = self.cursor.tip();
 
         match pipeline.step(l2_tip).await {
-            StepResult::PreparedAttributes => trace!("Perpared new attributes"),
+            StepResult::PreparedAttributes => trace!("Prepared new attributes"),
             StepResult::AdvancedOrigin => trace!("Advanced origin"),
             StepResult::OriginAdvanceErr(err) => warn!("Could not advance origin: {:?}", err),
             StepResult::StepFailed(err) => match err {


### PR DESCRIPTION
This PR fixes parsing of URLs to strings by removing the trailing `/` where necessary.